### PR TITLE
Enable EditorConfig in Project.xml

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -811,9 +811,6 @@
       <option name="XML_ALIGN_ATTRIBUTES" value="false" />
       <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
     </XML>
-    <editorconfig>
-      <option name="ENABLED" value="false" />
-    </editorconfig>
     <codeStyleSettings language="DB2">
       <option name="KEEP_LINE_BREAKS" value="false" />
     </codeStyleSettings>


### PR DESCRIPTION
I just noticed that the EditorConfig setting in IntelliJ is off by default, when using the files from this project.
After changing the setting, I got the diff in my `Project.xml`, which you can see here.